### PR TITLE
feat: Get display language names via Web API instead

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -34,8 +34,7 @@ export const languageNames = {
   system: 'system',
   // Get local display names
   ...supportedLocales
-    .map(locale => ({ [locale]: new Intl.DisplayNames(locale, { type: 'language' }).of(locale) }))
-    .reduce((acc, cur) => ({ ...acc, ...cur })),
+    .reduce((acc, locale) => ({ ...acc, [locale]: new Intl.DisplayNames(locale, { type: 'language' }).of(locale) }), {}),
 };
 
 export const languages = {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -16,19 +16,26 @@ import { de } from './lang/de';
 
 export const defaultNS = 'app';
 
+export const supportedLocales = [
+  "en",
+  "es",
+  "de",
+  "fr",
+  "fil",
+  "ja",
+  "nl",
+  "ur",
+  "yue",
+  "zh-Hans",
+  "zh-Hant",
+]
+
 export const languageNames = {
   system: 'system',
-  en: en.name,
-  es: es.name,
-  de: de.name,
-  fr: fr.name,
-  fil: fil.name,
-  ja: ja.name,
-  nl: nl.name,
-  ur: ur.name,
-  yue: yue.name,
-  'zh-Hans': zh_Hans.name,
-  'zh-Hant': zh_Hant.name,
+  // Get local display names
+  ...supportedLocales
+    .map(locale => ({ [locale]: new Intl.DisplayNames(locale, { type: "language" }).of(locale) }))
+    .reduce((acc, cur) => ({ ...acc, ...cur })),
 };
 
 export const languages = {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -17,24 +17,24 @@ import { de } from './lang/de';
 export const defaultNS = 'app';
 
 export const supportedLocales = [
-  "en",
-  "es",
-  "de",
-  "fr",
-  "fil",
-  "ja",
-  "nl",
-  "ur",
-  "yue",
-  "zh-Hans",
-  "zh-Hant",
+  'en',
+  'es',
+  'de',
+  'fr',
+  'fil',
+  'ja',
+  'nl',
+  'ur',
+  'yue',
+  'zh-Hans',
+  'zh-Hant',
 ]
 
 export const languageNames = {
   system: 'system',
   // Get local display names
   ...supportedLocales
-    .map(locale => ({ [locale]: new Intl.DisplayNames(locale, { type: "language" }).of(locale) }))
+    .map(locale => ({ [locale]: new Intl.DisplayNames(locale, { type: 'language' }).of(locale) }))
     .reduce((acc, cur) => ({ ...acc, ...cur })),
 };
 

--- a/src/i18n/lang/de.ts
+++ b/src/i18n/lang/de.ts
@@ -1,6 +1,5 @@
 // German
 export const de = {
-  name: 'Deutsch',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/en.ts
+++ b/src/i18n/lang/en.ts
@@ -1,6 +1,5 @@
 // English
 export const en = {
-  name: 'English',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/es.ts
+++ b/src/i18n/lang/es.ts
@@ -1,6 +1,5 @@
 // Spanish
 export const es = {
-  name: 'Español',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/fil.ts
+++ b/src/i18n/lang/fil.ts
@@ -1,6 +1,5 @@
 // Filipino
 export const fil = {
-  name: 'Filipino',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/fr.ts
+++ b/src/i18n/lang/fr.ts
@@ -1,6 +1,5 @@
 // French
 export const fr = {
-  name: 'français',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/ja.ts
+++ b/src/i18n/lang/ja.ts
@@ -1,6 +1,5 @@
 // Japanese
 export const ja = {
-  name: '日本語',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/nl.ts
+++ b/src/i18n/lang/nl.ts
@@ -1,6 +1,5 @@
 // Dutch
 export const nl = {
-  name: 'Dutch',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/ur.ts
+++ b/src/i18n/lang/ur.ts
@@ -1,6 +1,5 @@
 // Urdu
 export const ur = {
-  name: 'اردو',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/yue.ts
+++ b/src/i18n/lang/yue.ts
@@ -1,6 +1,5 @@
 // Cantonese
 export const yue = {
-  name: '廣東話',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/zh-Hans.ts
+++ b/src/i18n/lang/zh-Hans.ts
@@ -1,6 +1,5 @@
 // Simplified Chinese
 export const zh_Hans = {
-  name: '简体中文',
   translations: {
     auth: {
       login: {

--- a/src/i18n/lang/zh-Hant.ts
+++ b/src/i18n/lang/zh-Hant.ts
@@ -1,6 +1,5 @@
 // Traditional Chinese
 export const zh_Hant = {
-  name: '繁體中文',
   translations: {
     auth: {
       login: {


### PR DESCRIPTION
The display language names will be taken care of by Node.js' Web API implementation.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames