### PR TITLE
feat: added group permissions

### DIFF
--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -39,20 +39,39 @@ export const BSkyPost = Type.Object({
     ),
     acl: Type.Optional(
       Type.Object({
-        user: Type.Array(
-          Type.Object({
-            did: Type.String(),
-            permission: Type.Object({
-              read: Type.Boolean(),
-              interact: Type.Object({
-                reply: Type.Boolean(),
-                like: Type.Boolean(),
-                repost: Type.Boolean(),
-                quote: Type.Boolean(),
-                comment: Type.Boolean(),
+        group: Type.Optional(
+          Type.Array(
+            Type.Object({
+              list: Type.String(),
+              permission: Type.Object({
+                read: Type.Boolean(),
+                interact: Type.Object({
+                  reply: Type.Boolean(),
+                  like: Type.Boolean(),
+                  repost: Type.Boolean(),
+                  quote: Type.Boolean(),
+                  comment: Type.Boolean(),
+                }),
               }),
             }),
-          }),
+          ),
+        ),
+        user: Type.Optional(
+          Type.Array(
+            Type.Object({
+              did: Type.String(),
+              permission: Type.Object({
+                read: Type.Boolean(),
+                interact: Type.Object({
+                  reply: Type.Boolean(),
+                  like: Type.Boolean(),
+                  repost: Type.Boolean(),
+                  quote: Type.Boolean(),
+                  comment: Type.Boolean(),
+                }),
+              }),
+            }),
+          ),
         ),
       }),
     ),


### PR DESCRIPTION
---
name: Group permissions
about: more control over private posts
---

### Summary of Changes

This pull request includes changes to the `src/lib/bluesky/types/bsky-post.ts` file to enhance the access control list (ACL) structure for BlueSky posts. The most important changes involve the addition of a new optional `group` field and modifications to the existing `user` field within the ACL object.

Improvements to ACL structure:

* Added a new optional `group` field to the ACL object, which includes a list of groups and their respective permissions. This allows for more granular control over who can read, reply, like, repost, quote, and comment on a post.
* Modified the existing `user` field within the ACL object to be optional, allowing for more flexible ACL configurations.
