### PR TITLE
more additions to private posts

### DIFF
--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -213,7 +213,8 @@ async function decryptPrivatePost(post: BSkyPost) {
     return post.record.text;
   }
 
-  const { key } = post.record.encryption;
+  const { algorithm } = post.record.encryption;
+  const { key, length } = post.record.encryption.key;
   const encryptedText = post.record.encryptedText;
 
   try {
@@ -221,7 +222,7 @@ async function decryptPrivatePost(post: BSkyPost) {
     const keyData = new TextEncoder().encode(key);
 
     // Import the raw key
-    const cryptoKey = await window.crypto.subtle.importKey('raw', keyData, { name: 'AES-CBC', length: 256 }, false, [
+    const cryptoKey = await window.crypto.subtle.importKey('raw', keyData, { name: algorithm, length: length }, false, [
       'decrypt',
     ]);
 
@@ -235,7 +236,7 @@ async function decryptPrivatePost(post: BSkyPost) {
     // Decrypt the data
     const decryptedData = await window.crypto.subtle.decrypt(
       {
-        name: 'AES-CBC',
+        name: algorithm,
         iv: iv,
       },
       cryptoKey,

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -109,10 +109,15 @@ const PostDropdownMenu = ({ post, setTranslatedText }: { post: BSkyPost; setTran
         <DropdownMenuItem
           className="justify-between"
           onClick={(event) => {
-            event.stopPropagation();
-            navigator.clipboard.writeText(post.record.text);
-            toast.info('Copied post text to clipboard');
-            trackEvent('copyToClipboard', { type: 'post-text' });
+            if (post.record.text != undefined) {
+              event.stopPropagation();
+              navigator.clipboard.writeText(post.record.text);
+              toast.info('Copied post text to clipboard');
+              trackEvent('copyToClipboard', { type: 'post-text' });
+            } else {
+              event.stopPropagation();
+              toast.info('Cannot copy private posts');
+            }
           }}
         >
           {'copy post text'} <ClipboardIcon />

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -32,7 +32,10 @@ export const BSkyPost = Type.Object({
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(
       Type.Object({
-        key: Type.String(),
+        key: Type.Object({
+          key: Type.String(),
+          length: Type.Number(),
+        }),
         algorithm: Type.String(),
         encoding: Type.String(),
       }),

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -29,6 +29,7 @@ export const BSkyPost = Type.Object({
       }),
     ),
     text: Type.String(),
+    akariPublicKey: Type.String(),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(
       Type.Object({

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -29,7 +29,7 @@ export const BSkyPost = Type.Object({
       }),
     ),
     text: Type.Optional(Type.String()),
-    akariPublicKey: Type.String(),
+    akariPublicKey: Type.Optional(Type.String()),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(
       Type.Object({

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -28,7 +28,7 @@ export const BSkyPost = Type.Object({
         }),
       }),
     ),
-    text: Type.String(),
+    text: Type.Optional(Type.String()),
     akariPublicKey: Type.String(),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -28,7 +28,7 @@ export const BSkyPost = Type.Object({
         }),
       }),
     ),
-    text: Type.Optional(Type.String()),
+    text: Type.String() || Type.Literal('This post is private'),
     akariPublicKey: Type.Optional(Type.String()),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(


### PR DESCRIPTION
---
name: several additions and fixes to private posts
about: Private posts
---

### Summary of Changes
This pull request includes several changes to improve the handling of post text and encryption in the `post-card` component. The most important changes involve adding checks for undefined post text, modifying the decryption function to handle different encryption algorithms and key lengths, and updating the `BSkyPost` type definition to include optional fields.

Improvements to post text handling:

* [`src/components/post-card.tsx`](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210R112-R120): Added a check to ensure the post text is defined before copying it to the clipboard. If the post text is undefined, a message indicating that private posts cannot be copied is shown instead.

Enhancements to decryption process:

* [`src/components/post-card.tsx`](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210L216-R230): Updated the `decryptPrivatePost` function to use the encryption algorithm and key length specified in the post's encryption metadata, improving the flexibility and security of the decryption process. [[1]](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210L216-R230) [[2]](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210L238-R244)

Updates to type definitions:

* [`src/lib/bluesky/types/bsky-post.ts`](diffhunk://#diff-cf0062f95c69e458e81b1493eb9020902b5f35562bbaf2d934b84f0a511c80e3L31-R39): Modified the `BSkyPost` type to make the `text`, `akariPublicKey`, and `encryptedText` fields optional. Additionally, added a nested object for the encryption key with `key` and `length` properties.

### License Agreement

- [ x ] I understand that my contribution will be released under the **CC0 1.0 Universal license** and placed in the public domain.