### PR TITLE
same pr but for the correcter branch?

### DIFF
--- a/src/components/navigation/navbar/profile-link.tsx
+++ b/src/components/navigation/navbar/profile-link.tsx
@@ -21,7 +21,7 @@ export const ProfileLink = () => {
       className="flex flex-row items-center gap-2 p-3 rounded-sm hover:no-underline hover:bg-gray-200 dark:hover:bg-gray-700 justify-center"
     >
       <UserIcon className="hidden sm:flex size-6 xl:size-5 active:scale-90" />
-      <Avatar handle={handle} avatar={profile?.avatar} hover={false} className="size-6 sm:hidden" />
+      <Avatar handle={handle} avatar={profile?.avatar} hover={false} classNames={{ wrapper: 'size-6 sm:hidden' }} />
       <span className="hidden xl:block">{t('profile')}</span>
     </Link>
   );

--- a/src/components/navigation/sidebar/index.tsx
+++ b/src/components/navigation/sidebar/index.tsx
@@ -34,7 +34,7 @@ export const Sidebar = () => {
         <div className="divide-y gap-2 flex flex-col">
           {handle ? (
             <div className="flex flex-col">
-              <Avatar handle={handle} avatar={profile?.avatar} hover={false} className="size-12" />
+              <Avatar handle={handle} avatar={profile?.avatar} hover={false} classNames={{ image: 'size-12' }} />
               <div className="font-bold">{profile?.displayName}</div>
               <Handle handle={handle} />
               <div className="flex flex-row items-center text-sm ">

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -213,7 +213,8 @@ async function decryptPrivatePost(post: BSkyPost) {
     return post.record.text;
   }
 
-  const { key } = post.record.encryption;
+  const { algorithm } = post.record.encryption;
+  const { key, length } = post.record.encryption.key;
   const encryptedText = post.record.encryptedText;
 
   try {
@@ -221,7 +222,7 @@ async function decryptPrivatePost(post: BSkyPost) {
     const keyData = new TextEncoder().encode(key);
 
     // Import the raw key
-    const cryptoKey = await window.crypto.subtle.importKey('raw', keyData, { name: 'AES-CBC', length: 256 }, false, [
+    const cryptoKey = await window.crypto.subtle.importKey('raw', keyData, { name: algorithm, length: length }, false, [
       'decrypt',
     ]);
 
@@ -235,7 +236,7 @@ async function decryptPrivatePost(post: BSkyPost) {
     // Decrypt the data
     const decryptedData = await window.crypto.subtle.decrypt(
       {
-        name: 'AES-CBC',
+        name: algorithm,
         iv: iv,
       },
       cryptoKey,

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -109,10 +109,15 @@ const PostDropdownMenu = ({ post, setTranslatedText }: { post: BSkyPost; setTran
         <DropdownMenuItem
           className="justify-between"
           onClick={(event) => {
-            event.stopPropagation();
-            navigator.clipboard.writeText(post.record.text);
-            toast.info('Copied post text to clipboard');
-            trackEvent('copyToClipboard', { type: 'post-text' });
+            if (post.record.text != undefined) {
+              event.stopPropagation();
+              navigator.clipboard.writeText(post.record.text);
+              toast.info('Copied post text to clipboard');
+              trackEvent('copyToClipboard', { type: 'post-text' });
+            } else {
+              event.stopPropagation();
+              toast.info('Cannot copy private posts');
+            }
           }}
         >
           {'copy post text'} <ClipboardIcon />

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -51,20 +51,23 @@ const AvatarInner = ({
   avatar,
   labeler,
   list,
-  className,
+  classNames,
   hover = true,
 }: {
   handle: string;
   avatar: string | undefined;
   labeler?: boolean;
   list?: boolean;
-  className?: string;
+  classNames?: {
+    image?: string;
+    wrapper?: string;
+  };
   hover?: boolean;
 }) => {
   const content = (
     <Link to="/profile/$handle" params={{ handle }} onClick={(event) => event.stopPropagation()}>
-      <AvatarWrapper className={cn((labeler || list) && 'aspect-square rounded-sm', className)}>
-        <AvatarImage src={avatar} />
+      <AvatarWrapper className={cn((labeler || list) && 'aspect-square rounded-sm border-2', classNames?.wrapper)}>
+        <AvatarImage src={avatar} className={classNames?.image} />
         <AvatarFallback>{handle}</AvatarFallback>
       </AvatarWrapper>
     </Link>

--- a/src/components/ui/banner.tsx
+++ b/src/components/ui/banner.tsx
@@ -1,5 +1,18 @@
+import { cn } from '@/lib/utils';
 import { Image } from './image';
 
-export const Banner = ({ banner }: { banner: string | undefined }) => {
-  return <Image src={banner} clickable={false} classNames={{ image: 'w-full h-36 object-cover' }} />;
+export const Banner = ({
+  banner,
+  classNames,
+}: {
+  banner: string | undefined;
+  classNames?: { wrapper?: string; image?: string };
+}) => {
+  return (
+    <Image
+      src={banner}
+      clickable={false}
+      classNames={{ image: cn('w-full h-36 object-cover', classNames?.image), wrapper: classNames?.wrapper }}
+    />
+  );
 };

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -32,7 +32,10 @@ export const BSkyPost = Type.Object({
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(
       Type.Object({
-        key: Type.String(),
+        key: Type.Object({
+          key: Type.String(),
+          length: Type.Number(),
+        }),
         algorithm: Type.String(),
         encoding: Type.String(),
       }),

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -29,6 +29,7 @@ export const BSkyPost = Type.Object({
       }),
     ),
     text: Type.String(),
+    akariPublicKey: Type.String(),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(
       Type.Object({

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -39,20 +39,39 @@ export const BSkyPost = Type.Object({
     ),
     acl: Type.Optional(
       Type.Object({
-        user: Type.Array(
-          Type.Object({
-            did: Type.String(),
-            permission: Type.Object({
-              read: Type.Boolean(),
-              interact: Type.Object({
-                reply: Type.Boolean(),
-                like: Type.Boolean(),
-                repost: Type.Boolean(),
-                quote: Type.Boolean(),
-                comment: Type.Boolean(),
+        group: Type.Optional(
+          Type.Array(
+            Type.Object({
+              list: Type.String(),
+              permission: Type.Object({
+                read: Type.Boolean(),
+                interact: Type.Object({
+                  reply: Type.Boolean(),
+                  like: Type.Boolean(),
+                  repost: Type.Boolean(),
+                  quote: Type.Boolean(),
+                  comment: Type.Boolean(),
+                }),
               }),
             }),
-          }),
+          ),
+        ),
+        user: Type.Optional(
+          Type.Array(
+            Type.Object({
+              did: Type.String(),
+              permission: Type.Object({
+                read: Type.Boolean(),
+                interact: Type.Object({
+                  reply: Type.Boolean(),
+                  like: Type.Boolean(),
+                  repost: Type.Boolean(),
+                  quote: Type.Boolean(),
+                  comment: Type.Boolean(),
+                }),
+              }),
+            }),
+          ),
         ),
       }),
     ),

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -29,7 +29,7 @@ export const BSkyPost = Type.Object({
       }),
     ),
     text: Type.Optional(Type.String()),
-    akariPublicKey: Type.String(),
+    akariPublicKey: Type.Optional(Type.String()),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(
       Type.Object({

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -28,7 +28,7 @@ export const BSkyPost = Type.Object({
         }),
       }),
     ),
-    text: Type.String(),
+    text: Type.Optional(Type.String()),
     akariPublicKey: Type.String(),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -29,6 +29,33 @@ export const BSkyPost = Type.Object({
       }),
     ),
     text: Type.String(),
+    encryptedText: Type.Optional(Type.String()),
+    encryption: Type.Optional(
+      Type.Object({
+        key: Type.String(),
+        algorithm: Type.String(),
+        encoding: Type.String(),
+      }),
+    ),
+    acl: Type.Optional(
+      Type.Object({
+        user: Type.Array(
+          Type.Object({
+            did: Type.String(),
+            permission: Type.Object({
+              read: Type.Boolean(),
+              interact: Type.Object({
+                reply: Type.Boolean(),
+                like: Type.Boolean(),
+                repost: Type.Boolean(),
+                quote: Type.Boolean(),
+                comment: Type.Boolean(),
+              }),
+            }),
+          }),
+        ),
+      }),
+    ),
   }),
   embed: Type.Optional(BSkyPostEmbed),
   replyCount: Type.Number(),

--- a/src/lib/bluesky/types/bsky-post.ts
+++ b/src/lib/bluesky/types/bsky-post.ts
@@ -28,7 +28,7 @@ export const BSkyPost = Type.Object({
         }),
       }),
     ),
-    text: Type.Optional(Type.String()),
+    text: Type.String() || Type.Literal('This post is private'),
     akariPublicKey: Type.Optional(Type.String()),
     encryptedText: Type.Optional(Type.String()),
     encryption: Type.Optional(

--- a/src/routes/messages/index.lazy.tsx
+++ b/src/routes/messages/index.lazy.tsx
@@ -30,7 +30,7 @@ function Conversation({ convo }: { convo: BSkyConvo }) {
         key={member.did}
       >
         <Link to="/profile/$handle" params={{ handle: member.handle ?? member.did }} className="hover:no-underline">
-          <Avatar handle={member.handle} avatar={member.avatar} className="size-14" />
+          <Avatar handle={member.handle} avatar={member.avatar} classNames={{ image: 'size-14' }} />
         </Link>
         <div className="flex flex-col">
           <div className="flex flex-row gap-2 items-center">

--- a/src/routes/notifications/components/follow-notification.tsx
+++ b/src/routes/notifications/components/follow-notification.tsx
@@ -22,7 +22,11 @@ export function FollowNotification({ notification }: { notification: BSkyFollowN
         <div className="hover:no-underline w-full">
           <div className="px-2">
             <div className="flex flex-row gap-1 max-h-16">
-              <Avatar handle={notification.author.handle} avatar={notification.author.avatar} className="size-8" />
+              <Avatar
+                handle={notification.author.handle}
+                avatar={notification.author.avatar}
+                classNames={{ wrapper: 'size-8' }}
+              />
             </div>
             <div>
               {notification.author.displayName} {t('followedYou')}

--- a/src/routes/notifications/components/like-notification.tsx
+++ b/src/routes/notifications/components/like-notification.tsx
@@ -41,7 +41,7 @@ export function LikeNotification({ notifications }: { notifications: BSkyLikeNot
                   key={notification.author.did}
                   handle={notification.author.handle}
                   avatar={notification.author.avatar}
-                  className="size-8"
+                  classNames={{ wrapper: 'size-8' }}
                 />
               ))}
             </div>

--- a/src/routes/notifications/components/mention-notification.tsx
+++ b/src/routes/notifications/components/mention-notification.tsx
@@ -8,7 +8,7 @@ export function MentionNotification({ notification }: { notification: BSkyMentio
   return (
     <div className="flex flex-row gap-2 p-2">
       <div className="flex flex-shrink-0 w-12 justify-end aspect-square">
-        <Avatar handle={notification.author.handle} avatar={notification.author.avatar} className="size-8" />
+        <Avatar handle={notification.author.handle} avatar={notification.author.avatar} classNames={{ wrapper: 'size-8' }} />
       </div>
       <div className="flex-grow">
         <div>

--- a/src/routes/notifications/components/quote-notification.tsx
+++ b/src/routes/notifications/components/quote-notification.tsx
@@ -21,7 +21,11 @@ export function QuoteNotification({ notification }: { notification: BSkyQuoteNot
         </div>
         <div>
           <div className="flex flex-row gap-1 overflow-hidden max-h-16">
-            <Avatar handle={notification.author.handle} avatar={notification.author.avatar} className="size-8" />
+            <Avatar
+              handle={notification.author.handle}
+              avatar={notification.author.avatar}
+              classNames={{ wrapper: 'size-8' }}
+            />
           </div>
           <div>
             {notification.author.displayName} {t('quotedYourPost')}

--- a/src/routes/notifications/components/reply-notification.tsx
+++ b/src/routes/notifications/components/reply-notification.tsx
@@ -22,7 +22,7 @@ export function ReplyNotification({ notification }: { notification: BSkyReplyNot
           <Avatar
             handle={notification.author.handle}
             avatar={notification.author.avatar}
-            className="stroke-green-400 size-10"
+            classNames={{ wrapper: 'stroke-green-400 size-10' }}
           />
         </div>
         <div className="hover:no-underline w-full">

--- a/src/routes/notifications/components/repost-notification.tsx
+++ b/src/routes/notifications/components/repost-notification.tsx
@@ -25,7 +25,11 @@ export function RepostNotification({ notification }: { notification: BSkyRepostN
         <div className="hover:no-underline w-full">
           <div className="px-2">
             <div className="flex flex-row gap-1 max-h-16">
-              <Avatar handle={notification.author.handle} avatar={notification.author.avatar} className="size-8" />
+              <Avatar
+                handle={notification.author.handle}
+                avatar={notification.author.avatar}
+                classNames={{ wrapper: 'size-8' }}
+              />
             </div>
             <div>
               {notification.author.displayName} {t('repostedYourPost')}

--- a/src/routes/notifications/components/starterpack-joined-notification.tsx
+++ b/src/routes/notifications/components/starterpack-joined-notification.tsx
@@ -7,7 +7,7 @@ export function StarterpackJoinedNotification({ notification }: { notification: 
   return (
     <div>
       <div className="flex flex-row gap-1 overflow-hidden max-h-16">
-        <Avatar handle={notification.author.handle} avatar={notification.author.avatar} className="size-8" />
+        <Avatar handle={notification.author.handle} avatar={notification.author.avatar} classNames={{ wrapper: 'size-8' }} />
       </div>
       <div>
         {notification.author.displayName} {t('joinedYourStarterpack')}


### PR DESCRIPTION
---
name: adding more functionality and the newer spec for private posts
about: private posts 
---

### Summary of Changes
This pull request includes several changes to improve the handling of private posts and refactor the `Avatar` component to use more flexible class names. The most important changes include adding support for decrypting private posts, updating the `Avatar` component to accept a `classNames` prop, and modifying various components to use the new `Avatar` prop.

### Handling of Private Posts:

* [`src/components/post-card.tsx`](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210R215-R258): Added support for decrypting private posts with a new `decryptPrivatePost` function and updated the `PostCardInner` component to handle private post decryption. [[1]](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210R215-R258) [[2]](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210R277-R284) [[3]](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210L333-R392)
* [`src/lib/bluesky/types/bsky-post.ts`](diffhunk://#diff-cf0062f95c69e458e81b1493eb9020902b5f35562bbaf2d934b84f0a511c80e3L31-R81): Updated the `BSkyPost` type to include fields for encrypted text and encryption metadata.

### Refactoring `Avatar` Component:

* [`src/components/ui/avatar.tsx`](diffhunk://#diff-935eb7629191f58eab70d7e1b58b18c7a0abe0250074ab37874bd3a0572e820aL54-R70): Refactored the `Avatar` component to accept a `classNames` prop instead of a single `className` for more flexible styling.
* Various files: Updated multiple components to use the new `classNames` prop of the `Avatar` component. [[1]](diffhunk://#diff-55b5cad421b11eeff15ec828611a470766d9fe26f0831f3f498a5e03fe0e5781L24-R24) [[2]](diffhunk://#diff-450b5dda792e1edf64f556fc1b6a98278127e3a0d2532c0d579bd2c79dbc572fL37-R37) [[3]](diffhunk://#diff-273f80dce17b34628dc16f4d3d0b5d4e1a0085061fbd3d1bb93b57f35c9dfd31L33-R33) [[4]](diffhunk://#diff-383706dd2062ec4eb4e92e8f6894d5f6ebc8c0937a06cf08f4f4e411bfaa19e7L25-R29) [[5]](diffhunk://#diff-13d887b9debd5e7e81d994016575bb0db84650932def801bb0adfe2533fe9991L44-R44) [[6]](diffhunk://#diff-174592abd1b45788325261fb378477fa3b3d67e741d466e4c170eeb8389e244cL11-R11) [[7]](diffhunk://#diff-90b2334fba0abd09d4f8ff0aface4272ea3c150aadb99ec5a52102dcb2dc85a8L24-R28) [[8]](diffhunk://#diff-4a9aaf2a7f133c870b7cc16df710301f88b276d54c3299d5695c496d6838ea61L25-R25) [[9]](diffhunk://#diff-3835fc60e0cde637b435fa77b66967ed5a2e647447d438bbfa8460a9a159c4f6L28-R32) [[10]](diffhunk://#diff-71bd5168415826be9522beb5dfc2342047fb72ec28aef921419baec7d325c8beL10-R10)

### Additional Improvements:

* [`src/components/post-card.tsx`](diffhunk://#diff-bf1589dda038121aa9bdcf0565df6c1cd75d1fb3eb1d552a46c16f217b831210L38-R38): Added `useEffect` import to handle side effects for decrypting private posts.
* [`src/routes/profile/$handle/index.lazy.tsx`](diffhunk://#diff-0f216241d38043da811ac5fd612279951aebfb6e2f686e3b00f6f71cebaa51ffR185): Added a check for blocked profiles and updated the UI to reflect the blocked state. [[1]](diffhunk://#diff-0f216241d38043da811ac5fd612279951aebfb6e2f686e3b00f6f71cebaa51ffR185) [[2]](diffhunk://#diff-0f216241d38043da811ac5fd612279951aebfb6e2f686e3b00f6f71cebaa51ffL200-R237)

These changes collectively enhance the handling of private posts and improve the flexibility of the `Avatar` component across the codebase.

### License Agreement

- [x] I understand that my contribution will be released under the **CC0 1.0 Universal license** and placed in the public domain.